### PR TITLE
Expose existing MCP server through Azure API Management using Bicep

### DIFF
--- a/.github/agents/apim-mcp-bicep.agent.md
+++ b/.github/agents/apim-mcp-bicep.agent.md
@@ -1,0 +1,146 @@
+# Exposing MCP Servers Through Azure API Management Using Bicep
+
+This document captures hard-won lessons from implementing Infrastructure-as-Code for MCP (Model Context Protocol) server exposure through Azure API Management. It is intended for agents working on similar tasks.
+
+## The Key Lesson: Don't Over-Research — Reverse-Engineer Instead
+
+### What didn't work
+
+The initial approach was to exhaustively research the problem before writing any code:
+- Searched Bicep type registries, Azure REST API specs, the bicep-types-az GitHub repo
+- Queried the Azure Resource Provider for `mcpServers` resource types
+- Searched 475+ REST API operations for MCP-related endpoints
+- Checked Azure Verified Modules
+
+**Every single search came up empty.** MCP support in APIM is new enough that it's not in published schemas, type definitions, or public specs. An agent could spend hours in this research loop and make zero progress.
+
+### What worked: Collaborative reverse-engineering
+
+The human suggested a much more effective approach:
+
+1. **Provision a bare APIM instance** using the existing Bicep (`azd provision`)
+2. **Have the human manually create an MCP server** through the Azure portal, following the [official docs](https://learn.microsoft.com/en-us/azure/api-management/expose-existing-mcp-server)
+3. **Agent examines what the portal created** via `az rest` calls against the ARM API with a preview API version
+4. **Agent writes Bicep** based on the observed resource structure
+5. **Agent deploys to a separate `azd` environment** to test the Bicep
+6. **Compare** the Bicep-deployed resource against the portal-created one and iterate
+
+This took about 20 minutes total vs. potentially hours of fruitless research. The approach works for any Azure feature that's ahead of its published schemas.
+
+## Technical Findings
+
+### MCP servers use standard resource types with new properties
+
+The portal does **not** create a new `Microsoft.ApiManagement/service/mcpServers` resource type. Instead it creates:
+
+1. **A backend** (`Microsoft.ApiManagement/service/backends`) — holds the MCP server's base URL
+2. **An API** (`Microsoft.ApiManagement/service/apis`) — with MCP-specific properties:
+   - `type: 'mcp'` (not `http`, `soap`, `graphql`, or `websocket`)
+   - `mcpProperties.endpoints.mcp.uriTemplate` — the endpoint path on the backend
+   - `backendId` — references the backend resource
+   - `serviceUrl` is `null` (URL lives on the backend resource)
+   - `subscriptionRequired: false` by default
+
+### Preview API version required
+
+- `type: 'mcp'`, `mcpProperties`, and `backendId` are **invisible** at API version `2024-05-01` (stable)
+- They work at `2024-06-01-preview`, `2024-10-01-preview`, and `2025-03-01-preview`
+- If you query the API with a stable version, you get `ResourceNotFound` — the MCP API simply doesn't exist from that version's perspective
+
+### Bicep type checker workaround
+
+The Bicep compiler doesn't have `backendId`, `mcpProperties`, or `type:'mcp'` in its type definitions (even for preview API versions). Direct usage causes compile errors like:
+
+```
+The property "mcpProperties" is not allowed on objects of type "ApiCreateOrUpdatePropertiesOrApiContractProperties"
+```
+
+**Solution:** Use `union()` to merge known properties with the untyped MCP-specific ones:
+
+```bicep
+resource mcpApi 'Microsoft.ApiManagement/service/apis@2024-06-01-preview' = {
+  parent: apim
+  name: mcpServerName
+  properties: union({
+    // Properties known to the Bicep type system
+    displayName: mcpServerDisplayName
+    description: mcpServerDescription
+    path: mcpServerBasePath
+    protocols: ['https']
+    subscriptionRequired: false
+  }, {
+    // MCP-specific properties not yet in Bicep type definitions
+    type: 'mcp'
+    backendId: mcpBackend.name
+    mcpProperties: {
+      endpoints: {
+        mcp: {
+          uriTemplate: mcpServerEndpointUriTemplate
+        }
+      }
+    }
+  })
+}
+```
+
+This compiles cleanly and deploys correctly. The `union()` approach bypasses compile-time type checking while still producing valid ARM JSON.
+
+### Backend resource structure
+
+```bicep
+resource mcpBackend 'Microsoft.ApiManagement/service/backends@2024-06-01-preview' = {
+  parent: apim
+  name: '${mcpServerName}-backend'
+  properties: {
+    protocol: 'http'
+    url: mcpServerBackendBaseUrl  // e.g. 'https://learn.microsoft.com'
+  }
+}
+```
+
+Note: `protocol` is `'http'` (this refers to the HTTP protocol for REST communication, not the URL scheme — the actual URL uses HTTPS).
+
+## How to Examine Azure Resources Created by the Portal
+
+When the portal creates resources that aren't in published schemas, use `az rest` with a preview API version:
+
+```bash
+# List APIs (including MCP type)
+az rest --method GET \
+  --url "https://management.azure.com/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ApiManagement/service/{apim}/apis?api-version=2024-06-01-preview"
+
+# Get backend details
+az rest --method GET \
+  --url "https://management.azure.com/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ApiManagement/service/{apim}/backends?api-version=2024-06-01-preview"
+
+# Get policies
+az rest --method GET \
+  --url "https://management.azure.com/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ApiManagement/service/{apim}/apis/{api-name}/policies?api-version=2024-06-01-preview"
+```
+
+Try multiple API versions. The valid ones for APIM as of Feb 2026 include: `2024-05-01`, `2024-06-01-preview`, `2024-10-01-preview`, `2025-03-01-preview`.
+
+## Testing Strategy
+
+Use separate `azd` environments to test changes without affecting the manually-created reference:
+
+- `manual` environment — human creates resources via portal (the reference)
+- `bicep-test` environment — agent deploys Bicep (the test)
+
+Then compare the two by querying both with `az rest` and diffing the output. This makes it safe to iterate without risk.
+
+## Useful References
+
+- [Expose and govern an existing MCP server](https://learn.microsoft.com/en-us/azure/api-management/expose-existing-mcp-server)
+- [About MCP servers in Azure API Management](https://learn.microsoft.com/en-us/azure/api-management/mcp-server-overview)
+- [Sample: remote-mcp-apim-functions-python](https://github.com/Azure-Samples/remote-mcp-apim-functions-python) (89% Bicep — good reference for larger APIM+MCP setups with OAuth)
+- [Microsoft.ApiManagement/service/apis Bicep reference](https://learn.microsoft.com/en-us/azure/templates/microsoft.apimanagement/service/apis) (does NOT include MCP properties yet)
+
+## When This Guidance May Become Outdated
+
+Microsoft may eventually:
+- Publish `mcpProperties` and `type:'mcp'` in the Bicep type definitions
+- Release a stable (non-preview) API version that supports MCP
+- Introduce a dedicated `mcpServers` sub-resource type
+
+When any of these happen, the `union()` workaround may no longer be needed and the resource definitions can be simplified. Check whether the Bicep compiler accepts `type: 'mcp'` directly before applying the workaround.

--- a/.github/workflows/apim-provision.yml
+++ b/.github/workflows/apim-provision.yml
@@ -47,6 +47,12 @@ jobs:
       AZURE_LOCATION: eastus
       AZURE_APIM_PUBLISHER_EMAIL: ci@example.com
       AZURE_APIM_PUBLISHER_NAME: CI Publisher
+      AZURE_MCP_SERVER_DISPLAY_NAME: CI MCP Server
+      AZURE_MCP_SERVER_NAME: ci-mcp-server
+      AZURE_MCP_SERVER_BASE_PATH: mcp
+      AZURE_MCP_SERVER_DESCRIPTION: MCP server for CI testing
+      AZURE_MCP_SERVER_BACKEND_BASE_URL: https://learn.microsoft.com
+      AZURE_MCP_SERVER_ENDPOINT_URI_TEMPLATE: /api/mcp
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # APIM MCP Container Apps
 
-Azure API Management (Standard V2) infrastructure deployed with Bicep and the Azure Developer CLI (`azd`).
+Azure API Management (Standard V2) infrastructure with MCP (Model Context Protocol) server exposure, deployed with Bicep and the Azure Developer CLI (`azd`).
 
 ## Architecture
 
-This project provisions an Azure API Management instance using the **Standard V2** SKU via Bicep templates that are compatible with the Azure Developer CLI.
+This project provisions an Azure API Management instance using the **Standard V2** SKU and configures it to expose an existing MCP server, enabling LLMs and AI agents to securely access tools through the MCP protocol. See [Expose and govern an existing MCP server](https://learn.microsoft.com/en-us/azure/api-management/expose-existing-mcp-server) for background.
 
 ### Resources Created
 
@@ -12,6 +12,8 @@ This project provisions an Azure API Management instance using the **Standard V2
 |----------|-------------|
 | **Resource Group** | Container for all deployed resources |
 | **Azure API Management** | Standard V2 SKU instance |
+| **APIM Backend** | Backend pointing to the MCP server base URL |
+| **APIM MCP API** | API of type `mcp` with `mcpProperties` exposing the MCP endpoint |
 
 ## Prerequisites
 
@@ -42,9 +44,20 @@ This project provisions an Azure API Management instance using the **Standard V2
 
    You will be prompted for:
    - **Environment name** – used to name the resource group and resources
-   - **Azure location** – region for deployment (e.g., `eastus`)
+   - **Azure location** – region for deployment (e.g., `japaneast`)
    - **Publisher email** – required by API Management
    - **Publisher name** – organization name shown in the developer portal
+
+   You also need to set the MCP server configuration:
+
+   ```bash
+   azd env set AZURE_MCP_SERVER_DISPLAY_NAME "Microsoft Learn MCP Server"
+   azd env set AZURE_MCP_SERVER_NAME "microsoft-learn-mcp-server"
+   azd env set AZURE_MCP_SERVER_BASE_PATH "mslearn"
+   azd env set AZURE_MCP_SERVER_DESCRIPTION "Microsoft Learn MCP server exposed through APIM"
+   azd env set AZURE_MCP_SERVER_BACKEND_BASE_URL "https://learn.microsoft.com"
+   azd env set AZURE_MCP_SERVER_ENDPOINT_URI_TEMPLATE "/api/mcp"
+   ```
 
 4. **Tear down resources when done**
 
@@ -59,11 +72,12 @@ This project provisions an Azure API Management instance using the **Standard V2
 ├── infra/
 │   ├── main.bicep             # Main deployment (subscription scope)
 │   ├── main.parameters.json   # Parameter definitions with azd variable substitution
-│   ├── apim.bicep             # API Management module (Standard V2 SKU)
+│   ├── apim.bicep             # API Management module + MCP server config
 │   └── abbreviations.json     # Resource naming abbreviations
 ├── .github/
 │   ├── agents/
-│   │   └── apim.agent.md      # Agent notes and challenges
+│   │   ├── apim.agent.md           # Agent notes: APIM Bicep challenges
+│   │   └── apim-mcp-bicep.agent.md # Agent notes: MCP server IaC approach
 │   └── workflows/
 │       └── apim-provision.yml # CI workflow: lint, build, provision, teardown
 └── README.md

--- a/infra/apim.bicep
+++ b/infra/apim.bicep
@@ -13,6 +13,25 @@ param publisherEmail string
 @description('Publisher name for the API Management instance')
 param publisherName string
 
+@description('Display name for the MCP server')
+param mcpServerDisplayName string
+
+@description('Name (identifier) for the MCP server API')
+param mcpServerName string
+
+@description('Base path for the MCP server in APIM gateway')
+param mcpServerBasePath string
+
+@description('Description of the MCP server')
+param mcpServerDescription string
+
+@description('Backend MCP server base URL (e.g. https://learn.microsoft.com)')
+param mcpServerBackendBaseUrl string
+
+@description('MCP endpoint URI template on the backend (e.g. /api/mcp)')
+param mcpServerEndpointUriTemplate string
+
+// APIM instance (stable API version)
 resource apim 'Microsoft.ApiManagement/service@2024-05-01' = {
   name: name
   location: location
@@ -27,5 +46,43 @@ resource apim 'Microsoft.ApiManagement/service@2024-05-01' = {
   }
 }
 
+// Backend for the MCP server
+resource mcpBackend 'Microsoft.ApiManagement/service/backends@2024-06-01-preview' = {
+  parent: apim
+  name: '${mcpServerName}-backend'
+  properties: {
+    protocol: 'http'
+    url: mcpServerBackendBaseUrl
+  }
+}
+
+// MCP server API — requires preview API version for type:'mcp' and mcpProperties
+// Note: backendId, mcpProperties, and type:'mcp' are not yet in the published Bicep type definitions.
+// We use any() to bypass compile-time type checking for properties that are valid at runtime.
+resource mcpApi 'Microsoft.ApiManagement/service/apis@2024-06-01-preview' = {
+  parent: apim
+  name: mcpServerName
+  properties: union({
+    displayName: mcpServerDisplayName
+    description: mcpServerDescription
+    path: mcpServerBasePath
+    protocols: [
+      'https'
+    ]
+    subscriptionRequired: false
+  }, {
+    type: 'mcp'
+    backendId: mcpBackend.name
+    mcpProperties: {
+      endpoints: {
+        mcp: {
+          uriTemplate: mcpServerEndpointUriTemplate
+        }
+      }
+    }
+  })
+}
+
 output name string = apim.name
 output gatewayUrl string = apim.properties.gatewayUrl
+output mcpServerUrl string = '${apim.properties.gatewayUrl}/${mcpServerBasePath}/mcp'

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -15,6 +15,24 @@ param publisherEmail string
 @description('Publisher name for the API Management instance')
 param publisherName string
 
+@description('Display name for the MCP server')
+param mcpServerDisplayName string
+
+@description('Name (identifier) for the MCP server API')
+param mcpServerName string
+
+@description('Base path for the MCP server in APIM gateway')
+param mcpServerBasePath string
+
+@description('Description of the MCP server')
+param mcpServerDescription string
+
+@description('Backend MCP server base URL')
+param mcpServerBackendBaseUrl string
+
+@description('MCP endpoint URI template on the backend')
+param mcpServerEndpointUriTemplate string
+
 var abbrs = loadJsonContent('abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
 var tags = { 'azd-env-name': environmentName }
@@ -34,9 +52,16 @@ module apim 'apim.bicep' = {
     tags: tags
     publisherEmail: publisherEmail
     publisherName: publisherName
+    mcpServerDisplayName: mcpServerDisplayName
+    mcpServerName: mcpServerName
+    mcpServerBasePath: mcpServerBasePath
+    mcpServerDescription: mcpServerDescription
+    mcpServerBackendBaseUrl: mcpServerBackendBaseUrl
+    mcpServerEndpointUriTemplate: mcpServerEndpointUriTemplate
   }
 }
 
 output AZURE_RESOURCE_GROUP string = rg.name
 output AZURE_APIM_NAME string = apim.outputs.name
 output AZURE_APIM_GATEWAY_URL string = apim.outputs.gatewayUrl
+output AZURE_MCP_SERVER_URL string = apim.outputs.mcpServerUrl

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -13,6 +13,24 @@
     },
     "publisherName": {
       "value": "${AZURE_APIM_PUBLISHER_NAME}"
+    },
+    "mcpServerDisplayName": {
+      "value": "${AZURE_MCP_SERVER_DISPLAY_NAME}"
+    },
+    "mcpServerName": {
+      "value": "${AZURE_MCP_SERVER_NAME}"
+    },
+    "mcpServerBasePath": {
+      "value": "${AZURE_MCP_SERVER_BASE_PATH}"
+    },
+    "mcpServerDescription": {
+      "value": "${AZURE_MCP_SERVER_DESCRIPTION}"
+    },
+    "mcpServerBackendBaseUrl": {
+      "value": "${AZURE_MCP_SERVER_BACKEND_BASE_URL}"
+    },
+    "mcpServerEndpointUriTemplate": {
+      "value": "${AZURE_MCP_SERVER_ENDPOINT_URI_TEMPLATE}"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds Infrastructure-as-Code support for exposing an existing MCP (Model Context Protocol) server through Azure API Management using Bicep.

## What changed

| File | Change |
|------|--------|
| `infra/apim.bicep` | Added backend + MCP API resources using `2024-06-01-preview` API version with `union()` workaround for untyped `type:'mcp'`, `mcpProperties`, and `backendId` properties |
| `infra/main.bicep` | Added 6 MCP server parameters, pass-through to apim module, new `AZURE_MCP_SERVER_URL` output |
| `infra/main.parameters.json` | Added 6 azd environment variable mappings for MCP configuration |
| `README.md` | Updated architecture description, resources table, getting started with MCP env vars, project structure |
| `.github/workflows/apim-provision.yml` | Added MCP server env vars so CI provision succeeds |
| `.github/agents/apim-mcp-bicep.agent.md` | New agent guidance documenting the reverse-engineering approach |

## Approach

The MCP server feature in APIM is too new for published Bicep schemas. We used a collaborative reverse-engineering approach:
1. Provisioned a bare APIM instance via `azd provision`
2. Manually created an MCP server through the Azure portal
3. Examined the created resources via `az rest` with preview API versions
4. Wrote Bicep based on the observed resource structure
5. Deployed to a separate `azd` environment and verified the result matches

## Key technical findings

- MCP servers use `Microsoft.ApiManagement/service/apis` with `type: 'mcp'` and `mcpProperties` — no dedicated `mcpServers` resource type
- Requires API version `2024-06-01-preview` or later (invisible at stable `2024-05-01`)
- `union()` bypasses Bicep compile-time type checking for properties not yet in published schemas

## Testing

- [x] Local `azd provision` to `bicep-test` environment — MCP server created and verified via REST API
- [x] CI workflow (Build & Lint + Provision & Teardown) — passed in 9m 14s

Closes #3