### PR TITLE
Rename repo to apim-mcp-bicep and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A sample project demonstrating how to expose [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) servers through [Azure API Management](https://learn.microsoft.com/azure/api-management/) using Bicep and the [Azure Developer CLI (`azd`)](https://learn.microsoft.com/azure/developer/azure-developer-cli/).
 
+> **Agent notes:** See [.github/agents/apim-mcp-bicep.agent.md](.github/agents/apim-mcp-bicep.agent.md) for detailed technical lessons on implementing MCP server exposure via Bicep, including the `union()` workaround, preview API version requirements, and a reverse-engineering workflow for undocumented Azure features.
+
 ## Overview
 
 MCP enables LLMs and AI agents to discover and invoke tools exposed by backend servers. Azure API Management can act as a gateway in front of these MCP servers, providing governance, security, and observability.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# APIM MCP Container Apps
+# Expose MCP Servers Through Azure API Management Using Bicep
 
-Azure API Management (Standard V2) infrastructure with MCP (Model Context Protocol) server exposure, deployed with Bicep and the Azure Developer CLI (`azd`).
+A sample project demonstrating how to expose [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) servers through [Azure API Management](https://learn.microsoft.com/azure/api-management/) using Bicep and the [Azure Developer CLI (`azd`)](https://learn.microsoft.com/azure/developer/azure-developer-cli/).
 
-## Architecture
+## Overview
 
-This project provisions an Azure API Management instance using the **Standard V2** SKU and configures it to expose an existing MCP server, enabling LLMs and AI agents to securely access tools through the MCP protocol. See [Expose and govern an existing MCP server](https://learn.microsoft.com/en-us/azure/api-management/expose-existing-mcp-server) for background.
+MCP enables LLMs and AI agents to discover and invoke tools exposed by backend servers. Azure API Management can act as a gateway in front of these MCP servers, providing governance, security, and observability.
+
+This sample provisions an APIM **Standard V2** instance and configures it to expose an existing MCP server using the preview `type: 'mcp'` API definition and `mcpProperties`. For background, see [Expose and govern an existing MCP server](https://learn.microsoft.com/azure/api-management/expose-existing-mcp-server).
 
 ### Resources Created
 
@@ -14,6 +16,12 @@ This project provisions an Azure API Management instance using the **Standard V2
 | **Azure API Management** | Standard V2 SKU instance |
 | **APIM Backend** | Backend pointing to the MCP server base URL |
 | **APIM MCP API** | API of type `mcp` with `mcpProperties` exposing the MCP endpoint |
+
+### Key Bicep Details
+
+- The `Microsoft.ApiManagement/service/apis` resource uses the **`2024-06-01-preview`** API version, which supports `type: 'mcp'`, `backendId`, and `mcpProperties`.
+- `union()` is used to combine standard API properties with MCP-specific properties that are not yet in the published Bicep type definitions.
+- All resource names incorporate a `resourceToken` derived from `uniqueString()` to ensure uniqueness.
 
 ## Prerequisites
 
@@ -26,8 +34,8 @@ This project provisions an Azure API Management instance using the **Standard V2
 1. **Clone the repository**
 
    ```bash
-   git clone https://github.com/rukasakurai/apim-mcp-containerapps.git
-   cd apim-mcp-containerapps
+   git clone https://github.com/rukasakurai/apim-mcp-bicep.git
+   cd apim-mcp-bicep
    ```
 
 2. **Log in to Azure**
@@ -36,7 +44,22 @@ This project provisions an Azure API Management instance using the **Standard V2
    azd auth login
    ```
 
-3. **Provision the infrastructure**
+3. **Set MCP server configuration**
+
+   Configure the MCP server details before provisioning. The example below points to the Microsoft Learn MCP server:
+
+   ```bash
+   azd env set AZURE_MCP_SERVER_DISPLAY_NAME "Microsoft Learn MCP Server"
+   azd env set AZURE_MCP_SERVER_NAME "microsoft-learn-mcp-server"
+   azd env set AZURE_MCP_SERVER_BASE_PATH "mslearn"
+   azd env set AZURE_MCP_SERVER_DESCRIPTION "Microsoft Learn MCP server exposed through APIM"
+   azd env set AZURE_MCP_SERVER_BACKEND_BASE_URL "https://learn.microsoft.com"
+   azd env set AZURE_MCP_SERVER_ENDPOINT_URI_TEMPLATE "/api/mcp"
+   ```
+
+   To expose a different MCP server, replace the values above with your own server's URL and endpoint.
+
+4. **Provision the infrastructure**
 
    ```bash
    azd provision
@@ -48,18 +71,9 @@ This project provisions an Azure API Management instance using the **Standard V2
    - **Publisher email** – required by API Management
    - **Publisher name** – organization name shown in the developer portal
 
-   You also need to set the MCP server configuration:
+   After provisioning, the outputs include the APIM gateway URL and the full MCP server URL.
 
-   ```bash
-   azd env set AZURE_MCP_SERVER_DISPLAY_NAME "Microsoft Learn MCP Server"
-   azd env set AZURE_MCP_SERVER_NAME "microsoft-learn-mcp-server"
-   azd env set AZURE_MCP_SERVER_BASE_PATH "mslearn"
-   azd env set AZURE_MCP_SERVER_DESCRIPTION "Microsoft Learn MCP server exposed through APIM"
-   azd env set AZURE_MCP_SERVER_BACKEND_BASE_URL "https://learn.microsoft.com"
-   azd env set AZURE_MCP_SERVER_ENDPOINT_URI_TEMPLATE "/api/mcp"
-   ```
-
-4. **Tear down resources when done**
+5. **Tear down resources when done**
 
    ```bash
    azd down --force --purge
@@ -74,12 +88,14 @@ This project provisions an Azure API Management instance using the **Standard V2
 │   ├── main.parameters.json   # Parameter definitions with azd variable substitution
 │   ├── apim.bicep             # API Management module + MCP server config
 │   └── abbreviations.json     # Resource naming abbreviations
+├── docs/
+│   ├── azure-coding-agent-guide.md  # Azure coding agent guidance
+│   └── azure-oidc-setup.md          # OIDC setup instructions
 ├── .github/
-│   ├── agents/
-│   │   ├── apim.agent.md           # Agent notes: APIM Bicep challenges
-│   │   └── apim-mcp-bicep.agent.md # Agent notes: MCP server IaC approach
+│   ├── agents/                # Copilot agent notes
 │   └── workflows/
-│       └── apim-provision.yml # CI workflow: lint, build, provision, teardown
+│       ├── apim-provision.yml       # CI workflow: lint, build, provision, teardown
+│       └── azure-oidc-check.yml     # OIDC credential verification
 └── README.md
 ```
 
@@ -95,7 +111,7 @@ The **APIM Bicep Provision** workflow (`.github/workflows/apim-provision.yml`) r
 | Name | Type | Description |
 |------|------|-------------|
 | `AZURE_CLIENT_ID` | Variable | App registration client ID for OIDC |
-| `AZURE_TENANT_ID` | Secret | Azure AD tenant ID |
+| `AZURE_TENANT_ID` | Secret | Microsoft Entra ID tenant ID |
 | `AZURE_SUBSCRIPTION_ID` | Secret | Target Azure subscription ID |
 
 See [docs/azure-oidc-setup.md](docs/azure-oidc-setup.md) for OIDC setup instructions.

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,2 +1,2 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
-name: apim-mcp-containerapps
+name: apim-mcp-bicep


### PR DESCRIPTION
## Changes

- **Renamed project** from `apim-mcp-containerapps` to `apim-mcp-bicep` — the repo has no Container Apps, so the name now reflects the actual content (APIM + MCP + Bicep).
- **Rewrote README** to clearly position this as a sample for exposing MCP servers through Azure API Management using Bicep:
  - New title and overview section explaining MCP and APIM's gateway role
  - Added Key Bicep Details subsection (preview API version, `union()` workaround, `resourceToken`)
  - Reordered Getting Started so MCP server config (`azd env set`) comes before `azd provision`
  - Updated project structure to match actual files
  - Fixed "Azure AD" → "Microsoft Entra ID"
- **Updated `azure.yaml`** project name to `apim-mcp-bicep`

> **Note:** The `azure.yaml` change will trigger the `apim-provision.yml` workflow (path filter matches `azure.yaml`). The change is cosmetic (project name only) and the workflow validates Bicep files, so it should pass.

Closes #5